### PR TITLE
Use jsonnet for build pipeline

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,0 +1,142 @@
+local docker_defaults = {
+  username: {
+    from_secret: 'docker_username',
+  },
+  password: {
+    from_secret: 'docker_password',
+  },
+};
+
+local pipeline_defaults = {
+  kind: 'pipeline',
+  type: 'docker',
+};
+
+local trigger_on_tag = {
+  trigger: {
+    event: {
+      include: [
+        'tag',
+      ],
+    },
+  },
+};
+
+local trigger_on_promotion = {
+  trigger: {
+    event: [
+      'promote',
+    ],
+  },
+};
+
+local rspamd_image = 'rspamd/rspamd';
+
+local architecture_specific_pipeline(arch) = {
+  local step_default_settings = {
+    platform: 'linux/' + arch,
+    repo: rspamd_image,
+  },
+  local install_step(name, asan_tag) = {
+    name: name,
+    depends_on: [
+      'pkg_' + arch,
+    ],
+    image: 'plugins/docker',
+    settings: {
+      local asan_build_tag = if std.length(asan_tag) != 0 then ['ASAN_TAG=' + asan_tag] else [],
+      dockerfile: 'Dockerfile',
+      build_args: [
+        'LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}',
+        'TARGETARCH=' + arch,
+      ] + asan_build_tag,
+      squash: true,
+      tags: [
+        std.format('image%s-%s-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}', [asan_tag, arch]),
+      ],
+      target: 'install',
+    } + step_default_settings + docker_defaults,
+  },
+  name: 'rspamd_' + arch,
+  platform: {
+    os: 'linux',
+    arch: arch,
+  },
+  steps: [
+    {
+      name: 'pkg_' + arch,
+      image: 'plugins/docker',
+      settings: {
+        dockerfile: 'Dockerfile.pkg',
+        build_args: [
+          'RSPAMD_VERSION=${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}',
+          'TARGETARCH=' + arch,
+        ],
+        tags: [
+          std.format('pkg-%s-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}', arch),
+        ],
+        target: 'pkg',
+      } + step_default_settings + docker_defaults,
+    },
+    install_step('install_' + arch, ''),
+    install_step('install_asan_' + arch, '-asan'),
+  ],
+} + trigger_on_tag + pipeline_defaults;
+
+local multiarch_pipeline = {
+  name: 'rspamd_multiarch',
+  depends_on: [
+    'rspamd_amd64',
+    'rspamd_arm64',
+  ],
+  local multiarch_step(step_name, asan_tag) = {
+    name: step_name,
+    image: 'plugins/manifest',
+    settings: {
+      target: std.format('%s:image%s-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}', [rspamd_image, asan_tag]),
+      template: std.format('%s:image%s-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}', [rspamd_image, asan_tag]),
+      platforms: [
+        'linux/amd64',
+        'linux/arm64',
+      ],
+    } + docker_defaults,
+  },
+  steps: [
+    multiarch_step('multiarch_image', ''),
+    multiarch_step('multiarch_asan_image', '-asan'),
+  ],
+} + trigger_on_tag + pipeline_defaults;
+
+local promotion_multiarch(name, step_name, asan_tag) = {
+  name: name,
+  steps: [
+    {
+      name: step_name,
+      image: 'plugins/manifest',
+      settings: {
+        target: std.format('%s:%s${DRONE_SEMVER_SHORT}', [rspamd_image, asan_tag]),
+        template: std.format('%s:image-%sARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}', [rspamd_image, asan_tag]),
+        platforms: [
+          'linux/amd64',
+          'linux/arm64',
+        ],
+        tags: [
+          asan_tag + 'latest',
+          asan_tag + '${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}',
+        ],
+      } + docker_defaults,
+    },
+  ],
+} + trigger_on_promotion + pipeline_defaults;
+
+[
+  architecture_specific_pipeline('amd64'),
+  architecture_specific_pipeline('arm64'),
+  multiarch_pipeline,
+  promotion_multiarch('promotion_multiarch', 'promote_multiarch', ''),
+  promotion_multiarch('promotion_multiarch_asan', 'promote_multiarch_asan', 'asan-'),
+  {
+    kind: 'signature',
+    hmac: '0000000000000000000000000000000000000000000000000000000000000000',
+  },
+]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,217 +1,325 @@
-kind: pipeline
-type: docker
-name: rspamd_amd64
-
-platform:
-  os: linux
-  arch: amd64
-
-x-default-settings: &default_settings
-  username: { from_secret: docker_username }
-  password: { from_secret: docker_password }
-
-steps:
-  - name: pkg_amd64
-    image: plugins/docker
-    settings:
-      <<: *default_settings
-      dockerfile: Dockerfile.pkg
-      build_args:
-        - RSPAMD_VERSION=${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}
-        - TARGETARCH=amd64
-      platform: linux/amd64
-      repo: rspamd/rspamd
-      tags:
-        - pkg-amd64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      target: pkg
-
-  - name: install_amd64
-    depends_on: [ pkg_amd64 ]
-    image: plugins/docker
-    settings:
-      <<: *default_settings
-      dockerfile: Dockerfile
-      build_args:
-        - LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-        - TARGETARCH=amd64
-      platform: linux/amd64
-      repo: rspamd/rspamd
-      squash: true
-      tags:
-        - image-amd64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      target: install
-
-  - name: install_asan_amd64
-    depends_on: [ pkg_amd64 ]
-    image: plugins/docker
-    settings:
-      <<: *default_settings
-      dockerfile: Dockerfile
-      build_args:
-        - ASAN_TAG=-asan
-        - LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-        - TARGETARCH=amd64
-      platform: linux/amd64
-      repo: rspamd/rspamd
-      squash: true
-      tags:
-        - image-asan-amd64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      target: install
-
-trigger:
-  event:
-    include:
-    - tag
-
 ---
-kind: pipeline
-type: docker
-name: rspamd_arm64
-
-platform:
-  os: linux
-  arch: arm64
-
-x-default-settings: &default_settings
-  username: { from_secret: docker_username }
-  password: { from_secret: docker_password }
-
-steps:
-  - name: pkg_arm64
-    image: plugins/docker
-    settings:
-      <<: *default_settings
-      dockerfile: Dockerfile.pkg
-      build_args:
-        - RSPAMD_VERSION=${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}
-        - TARGETARCH=arm64
-      platform: linux/arm64
-      repo: rspamd/rspamd
-      tags:
-        - pkg-arm64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      target: pkg
-
-  - name: install_arm64
-    depends_on: [ pkg_arm64 ]
-    image: plugins/docker
-    settings:
-      <<: *default_settings
-      dockerfile: Dockerfile
-      build_args:
-        - LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-        - TARGETARCH=arm64
-      platform: linux/arm64
-      repo: rspamd/rspamd
-      squash: true
-      tags:
-        - image-arm64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      target: install
-
-  - name: install_asan_arm64
-    depends_on: [ pkg_arm64 ]
-    image: plugins/docker
-    settings:
-      <<: *default_settings
-      dockerfile: Dockerfile
-      build_args:
-        - ASAN_TAG=-asan
-        - LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-        - TARGETARCH=arm64
-      platform: linux/arm64
-      repo: rspamd/rspamd
-      squash: true
-      tags:
-        - image-asan-arm64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      target: install
-
-trigger:
-  event:
-    include:
-    - tag
-
+{
+   "kind": "pipeline",
+   "name": "rspamd_amd64",
+   "platform": {
+      "arch": "amd64",
+      "os": "linux"
+   },
+   "steps": [
+      {
+         "image": "plugins/docker",
+         "name": "pkg_amd64",
+         "settings": {
+            "build_args": [
+               "RSPAMD_VERSION=${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}",
+               "TARGETARCH=amd64"
+            ],
+            "dockerfile": "Dockerfile.pkg",
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platform": "linux/amd64",
+            "repo": "rspamd/rspamd",
+            "tags": [
+               "pkg-amd64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}"
+            ],
+            "target": "pkg",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      },
+      {
+         "depends_on": [
+            "pkg_amd64"
+         ],
+         "image": "plugins/docker",
+         "name": "install_amd64",
+         "settings": {
+            "build_args": [
+               "LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+               "TARGETARCH=amd64"
+            ],
+            "dockerfile": "Dockerfile",
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platform": "linux/amd64",
+            "repo": "rspamd/rspamd",
+            "squash": true,
+            "tags": [
+               "image-amd64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}"
+            ],
+            "target": "install",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      },
+      {
+         "depends_on": [
+            "pkg_amd64"
+         ],
+         "image": "plugins/docker",
+         "name": "install_asan_amd64",
+         "settings": {
+            "build_args": [
+               "LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+               "TARGETARCH=amd64",
+               "ASAN_TAG=-asan"
+            ],
+            "dockerfile": "Dockerfile",
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platform": "linux/amd64",
+            "repo": "rspamd/rspamd",
+            "squash": true,
+            "tags": [
+               "image-asan-amd64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}"
+            ],
+            "target": "install",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      }
+   ],
+   "trigger": {
+      "event": {
+         "include": [
+            "tag"
+         ]
+      }
+   },
+   "type": "docker"
+}
 ---
-kind: pipeline
-type: docker
-name: rspamd_multiarch
-depends_on: [ rspamd_amd64, rspamd_arm64 ]
-
-platform:
-  os: linux
-  arch: amd64
-
-x-default-settings: &default_settings
-  username: { from_secret: docker_username }
-  password: { from_secret: docker_password }
-
-steps:
-  - name: multiarch_image
-    image: plugins/manifest
-    settings:
-      <<: *default_settings
-      target: rspamd/rspamd:image-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      template: rspamd/rspamd:image-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      platforms:
-        - linux/amd64
-        - linux/arm64
-
-  - name: multiarch_asan_image
-    image: plugins/manifest
-    settings:
-      <<: *default_settings
-      target: rspamd/rspamd:image-asan-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      template: rspamd/rspamd:image-asan-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      platforms:
-        - linux/amd64
-        - linux/arm64
-
-trigger:
-  event:
-    include:
-    - tag
-
+{
+   "kind": "pipeline",
+   "name": "rspamd_arm64",
+   "platform": {
+      "arch": "arm64",
+      "os": "linux"
+   },
+   "steps": [
+      {
+         "image": "plugins/docker",
+         "name": "pkg_arm64",
+         "settings": {
+            "build_args": [
+               "RSPAMD_VERSION=${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}",
+               "TARGETARCH=arm64"
+            ],
+            "dockerfile": "Dockerfile.pkg",
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platform": "linux/arm64",
+            "repo": "rspamd/rspamd",
+            "tags": [
+               "pkg-arm64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}"
+            ],
+            "target": "pkg",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      },
+      {
+         "depends_on": [
+            "pkg_arm64"
+         ],
+         "image": "plugins/docker",
+         "name": "install_arm64",
+         "settings": {
+            "build_args": [
+               "LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+               "TARGETARCH=arm64"
+            ],
+            "dockerfile": "Dockerfile",
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platform": "linux/arm64",
+            "repo": "rspamd/rspamd",
+            "squash": true,
+            "tags": [
+               "image-arm64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}"
+            ],
+            "target": "install",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      },
+      {
+         "depends_on": [
+            "pkg_arm64"
+         ],
+         "image": "plugins/docker",
+         "name": "install_asan_arm64",
+         "settings": {
+            "build_args": [
+               "LONG_VERSION=${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+               "TARGETARCH=arm64",
+               "ASAN_TAG=-asan"
+            ],
+            "dockerfile": "Dockerfile",
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platform": "linux/arm64",
+            "repo": "rspamd/rspamd",
+            "squash": true,
+            "tags": [
+               "image-asan-arm64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}"
+            ],
+            "target": "install",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      }
+   ],
+   "trigger": {
+      "event": {
+         "include": [
+            "tag"
+         ]
+      }
+   },
+   "type": "docker"
+}
 ---
-kind: pipeline
-type: docker
-name: promotion_multiarch
-
-steps:
-  - name: promote_multiarch
-    image: plugins/manifest
-    settings:
-      username: { from_secret: docker_username }
-      password: { from_secret: docker_password }
-      target: rspamd/rspamd:${DRONE_SEMVER_SHORT}
-      template: rspamd/rspamd:image-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      platforms:
-        - linux/amd64
-        - linux/arm64
-      tags:
-        - latest
-        - ${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}
-
-trigger:
-  event:
-  - promote
+{
+   "depends_on": [
+      "rspamd_amd64",
+      "rspamd_arm64"
+   ],
+   "kind": "pipeline",
+   "name": "rspamd_multiarch",
+   "steps": [
+      {
+         "image": "plugins/manifest",
+         "name": "multiarch_image",
+         "settings": {
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platforms": [
+               "linux/amd64",
+               "linux/arm64"
+            ],
+            "target": "rspamd/rspamd:image-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+            "template": "rspamd/rspamd:image-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      },
+      {
+         "image": "plugins/manifest",
+         "name": "multiarch_asan_image",
+         "settings": {
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platforms": [
+               "linux/amd64",
+               "linux/arm64"
+            ],
+            "target": "rspamd/rspamd:image-asan-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+            "template": "rspamd/rspamd:image-asan-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      }
+   ],
+   "trigger": {
+      "event": {
+         "include": [
+            "tag"
+         ]
+      }
+   },
+   "type": "docker"
+}
 ---
-kind: pipeline
-type: docker
-name: promotion_multiarch_asan
-
-steps:
-  - name: promote_multiarch_asan
-    image: plugins/manifest
-    settings:
-      username: { from_secret: docker_username }
-      password: { from_secret: docker_password }
-      target: rspamd/rspamd:asan-${DRONE_SEMVER_SHORT}
-      template: rspamd/rspamd:image-asan-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}
-      platforms:
-        - linux/amd64
-        - linux/arm64
-      tags:
-        - asan-latest
-        - asan-${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}
-
-trigger:
-  event:
-  - promote
+{
+   "kind": "pipeline",
+   "name": "promotion_multiarch",
+   "steps": [
+      {
+         "image": "plugins/manifest",
+         "name": "promote_multiarch",
+         "settings": {
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platforms": [
+               "linux/amd64",
+               "linux/arm64"
+            ],
+            "tags": [
+               "latest",
+               "${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}"
+            ],
+            "target": "rspamd/rspamd:${DRONE_SEMVER_SHORT}",
+            "template": "rspamd/rspamd:image-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      }
+   ],
+   "trigger": {
+      "event": [
+         "promote"
+      ]
+   },
+   "type": "docker"
+}
+---
+{
+   "kind": "pipeline",
+   "name": "promotion_multiarch_asan",
+   "steps": [
+      {
+         "image": "plugins/manifest",
+         "name": "promote_multiarch_asan",
+         "settings": {
+            "password": {
+               "from_secret": "docker_password"
+            },
+            "platforms": [
+               "linux/amd64",
+               "linux/arm64"
+            ],
+            "tags": [
+               "asan-latest",
+               "asan-${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}"
+            ],
+            "target": "rspamd/rspamd:asan-${DRONE_SEMVER_SHORT}",
+            "template": "rspamd/rspamd:image-asan-ARCH-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+            "username": {
+               "from_secret": "docker_username"
+            }
+         }
+      }
+   ],
+   "trigger": {
+      "event": [
+         "promote"
+      ]
+   },
+   "type": "docker"
+}
+---
+{
+   "hmac": "0000000000000000000000000000000000000000000000000000000000000000",
+   "kind": "signature"
+}
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,6 @@ steps:
     image: plugins/docker
     settings:
       <<: *default_settings
-      debug: true
       dockerfile: Dockerfile.pkg
       build_args:
         - RSPAMD_VERSION=${DRONE_SEMVER_MAJOR}.${DRONE_SEMVER_MINOR}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ~~~
 mkdir dbdir
-chown 11333:11333 dbdir
-docker run -v ./dbdir:/var/lib/rspamd -ti rspamd/rspamd
+sudo chown 11333:11333 dbdir
+docker run -v `pwd`/dbdir:/var/lib/rspamd -ti rspamd/rspamd
 ~~~
 
 ## Acknowledgements


### PR DESCRIPTION
- Use jsonnet (no functional changes)
- Improve README instructions
- Revert debugging

TODO (later, once possible): use multiarch build image instead of multiple `FROM` hack in `Dockerfile.pkg`