### PR TITLE
Further neats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ ARG TARGETARCH
 ENV ASAN_TAG=$ASAN_TAG
 ENV TARGETARCH=$TARGETARCH
 
-RUN	mkdir /deb
-COPY	--from=pkg /deb/* /deb/
+COPY	--from=pkg /deb /deb
 
 RUN	apt-get update \
 	&& dpkg -i /deb/rspamd${ASAN_TAG}_*_${TARGETARCH}.deb /deb/rspamd${ASAN_TAG}-dbg_*_${TARGETARCH}.deb || true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,6 @@ VOLUME  [ "/var/lib/rspamd" ]
 
 CMD     [ "/usr/bin/rspamd", "-f" ]
 
+# https://www.rspamd.com/doc/workers
+# 11332 proxy ; 11333 normal ; 11334 controller
 EXPOSE  11332 11333 11334


### PR DESCRIPTION
Address some feedback raised in the [thread](https://github.com/rspamd/rspamd/issues/4400#issuecomment-1743918884).

`COPY --link` is interesting but doesn't work in our environment; alternative approach may be something like `RUN --mount` but I haven't tried it; squash step is achieving the same result currently and is able to squash things we couldn't without it.

I neither got `COPY` without `FROM` to work, [not clear that it's supposed to](https://docs.docker.com/engine/reference/builder/#copy).

`ENV` vars need to be where they are.