### PR TITLE
Run functional test on promotion

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -107,7 +107,35 @@ local multiarch_pipeline = {
   ],
 } + trigger_on_tag + pipeline_defaults;
 
+local prepromotion_test(arch, asan_tag) = {
+  name: 'prepromo_' + arch,
+  platform: {
+    os: 'linux',
+    arch: arch,
+  },
+  steps: [
+    {
+      name: 'pre_promotion_test',
+      image: std.format('%s:image-%s%s-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}', [rspamd_image, arch, asan_tag]),
+      user: 'root',
+      commands: [
+        'apt-get update',
+        'apt-get install -y git miltertest python3 python3-dev python3-pip python3-venv redis-server',
+        'python3 -mvenv $DRONE_WORKSPACE/venv',
+        'bash -c "source $DRONE_WORKSPACE/venv/bin/activate && pip3 install --no-cache --disable-pip-version-check --no-binary :all: setuptools==57.5.0"', # https://github.com/dmeranda/demjson/issues/43
+        'bash -c "source $DRONE_WORKSPACE/venv/bin/activate && pip3 install --no-cache --disable-pip-version-check --no-binary :all: demjson psutil requests robotframework tornado"',
+        'git clone -b ${DRONE_SEMVER_SHORT} https://github.com/rspamd/rspamd.git',
+        'RSPAMD_INSTALLROOT=/usr bash -c "source $DRONE_WORKSPACE/venv/bin/activate && umask 0000 && robot --removekeywords wuks --exclude isbroken $DRONE_WORKSPACE/rspamd/test/functional/cases"',
+      ],
+    },
+  ],
+} + trigger_on_promotion + pipeline_defaults;
+
 local promotion_multiarch(name, step_name, asan_tag) = {
+  depends_on: [
+    'prepromo_amd64',
+    'prepromo_arm64',
+  ],
   name: name,
   steps: [
     {
@@ -133,6 +161,8 @@ local promotion_multiarch(name, step_name, asan_tag) = {
   architecture_specific_pipeline('amd64'),
   architecture_specific_pipeline('arm64'),
   multiarch_pipeline,
+  prepromotion_test('amd64', ''),
+  prepromotion_test('arm64', ''),
   promotion_multiarch('promotion_multiarch', 'promote_multiarch', ''),
   promotion_multiarch('promotion_multiarch_asan', 'promote_multiarch_asan', 'asan-'),
   {

--- a/.drone.yml
+++ b/.drone.yml
@@ -250,6 +250,72 @@
 ---
 {
    "kind": "pipeline",
+   "name": "prepromo_amd64",
+   "platform": {
+      "arch": "amd64",
+      "os": "linux"
+   },
+   "steps": [
+      {
+         "commands": [
+            "apt-get update",
+            "apt-get install -y git miltertest python3 python3-dev python3-pip python3-venv redis-server",
+            "python3 -mvenv $DRONE_WORKSPACE/venv",
+            "bash -c \"source $DRONE_WORKSPACE/venv/bin/activate && pip3 install --no-cache --disable-pip-version-check --no-binary :all: setuptools==57.5.0\"",
+            "bash -c \"source $DRONE_WORKSPACE/venv/bin/activate && pip3 install --no-cache --disable-pip-version-check --no-binary :all: demjson psutil requests robotframework tornado\"",
+            "git clone -b ${DRONE_SEMVER_SHORT} https://github.com/rspamd/rspamd.git",
+            "RSPAMD_INSTALLROOT=/usr bash -c \"source $DRONE_WORKSPACE/venv/bin/activate && umask 0000 && robot --removekeywords wuks --exclude isbroken $DRONE_WORKSPACE/rspamd/test/functional/cases\""
+         ],
+         "image": "rspamd/rspamd:image-amd64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+         "name": "pre_promotion_test",
+         "user": "root"
+      }
+   ],
+   "trigger": {
+      "event": [
+         "promote"
+      ]
+   },
+   "type": "docker"
+}
+---
+{
+   "kind": "pipeline",
+   "name": "prepromo_arm64",
+   "platform": {
+      "arch": "arm64",
+      "os": "linux"
+   },
+   "steps": [
+      {
+         "commands": [
+            "apt-get update",
+            "apt-get install -y git miltertest python3 python3-dev python3-pip python3-venv redis-server",
+            "python3 -mvenv $DRONE_WORKSPACE/venv",
+            "bash -c \"source $DRONE_WORKSPACE/venv/bin/activate && pip3 install --no-cache --disable-pip-version-check --no-binary :all: setuptools==57.5.0\"",
+            "bash -c \"source $DRONE_WORKSPACE/venv/bin/activate && pip3 install --no-cache --disable-pip-version-check --no-binary :all: demjson psutil requests robotframework tornado\"",
+            "git clone -b ${DRONE_SEMVER_SHORT} https://github.com/rspamd/rspamd.git",
+            "RSPAMD_INSTALLROOT=/usr bash -c \"source $DRONE_WORKSPACE/venv/bin/activate && umask 0000 && robot --removekeywords wuks --exclude isbroken $DRONE_WORKSPACE/rspamd/test/functional/cases\""
+         ],
+         "image": "rspamd/rspamd:image-arm64-${DRONE_SEMVER_SHORT}-${DRONE_SEMVER_BUILD}",
+         "name": "pre_promotion_test",
+         "user": "root"
+      }
+   ],
+   "trigger": {
+      "event": [
+         "promote"
+      ]
+   },
+   "type": "docker"
+}
+---
+{
+   "depends_on": [
+      "prepromo_amd64",
+      "prepromo_arm64"
+   ],
+   "kind": "pipeline",
    "name": "promotion_multiarch",
    "steps": [
       {
@@ -284,6 +350,10 @@
 }
 ---
 {
+   "depends_on": [
+      "prepromo_amd64",
+      "prepromo_arm64"
+   ],
    "kind": "pipeline",
    "name": "promotion_multiarch_asan",
    "steps": [
@@ -319,7 +389,7 @@
 }
 ---
 {
-   "hmac": "f77545287adb21df04823be168f6059e32578798dd3fe8fc99671545f126c151",
+   "hmac": "fc3654b9dbbe0df54c08e666a6aa1f94606c9d24e37bd94809076091e583600a",
    "kind": "signature"
 }
 ...


### PR DESCRIPTION
Currently promotion step needs to be run before new images would be given any interesting tags; that provides an opportunity to inspect them ahead of time but that's tedious and might not be very helpful, rather we might run functional tests as part of promotion & fire it blind. Possibly we should better do away with promotion entirely but as-is it's still there...