### PR TITLE
Host dependencies in a separate, reproducible layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,14 @@ RUN	--mount=type=cache,from=pkg,source=/deb,target=/deb apt-get update \
 	&& dpkg -i /deb/rspamd${ASAN_TAG}_*_${TARGETARCH}.deb /deb/rspamd${ASAN_TAG}-dbg_*_${TARGETARCH}.deb || true \
 	&& apt-get install -f -y \
 	&& apt-get -q clean \
-	&& dpkg-query --no-pager -l rspamd${ASAN_TAG} \
-	&& rm -rf /var/cache/debconf /var/lib/apt/lists
+	&& apt-get purge -y rspamd${ASAN_TAG} \
+	&& userdel _rspamd \
+	&& rm -rf /var/cache/ldconfig/aux-cache /var/lib/apt/lists/* /var/log/apt/* /var/log/dpkg.log \
+	&& bash -c "find / -mount -newer /proc/1 -not -path '/dev/**' -not -path '/proc/**' -not -path '/sys/**' | xargs touch -h -d '2000-01-01 00:00:00'"
+
+RUN	--mount=type=cache,from=pkg,source=/deb,target=/deb dpkg -i /deb/rspamd${ASAN_TAG}_*_${TARGETARCH}.deb /deb/rspamd${ASAN_TAG}-dbg_*_${TARGETARCH}.deb \
+	&& rm -rf /var/log/dpkg.log
+
 COPY	lid.176.ftz /usr/share/rspamd/languages/fasttext_model.ftz
 
 USER	11333:11333


### PR DESCRIPTION
Install dependencies for Rspamd in a separate layer, with the idea being that these would see relatively infrequent updates.

For that to be actually useful it should be reproducible, so to ensure reproducibility:

* hack timestamps
* avoid removing directories present in parent image
* delete ldconfig aux-cache

Layer hosting the application misses similar treatment: I think that's OK.

Layer hosting the language identification model misses some treatment & might better be fixed.

Calls for fixes from [rspamd#4761](https://github.com/rspamd/rspamd/pull/4761).