### PR TITLE
Unbreak docker build

### DIFF
--- a/patches/rspamd-docker-debian.diff
+++ b/patches/rspamd-docker-debian.diff
@@ -25,17 +25,16 @@ index 3d4322117..2a69f77ab 100644
         mkdir -p $SERVER_HOME $SERVER_LOG || true
         chown $SERVER_USER: $SERVER_HOME $SERVER_LOG
 diff --git a/debian/rules b/debian/rules
-index 74771ede3..3c71812d6 100755
+index e5432c9cc..3c71812d6 100755
 --- a/debian/rules
 +++ b/debian/rules
-@@ -28,7 +28,9 @@ endif
+@@ -28,7 +28,8 @@ endif
  override_dh_auto_configure: $(patsubst %,configure_%,$(FLAVORS))
  configure_%:
  	mkdir -p $(builddir)$*
 -	cd $(builddir)$* && cmake ../../../  -DCONFDIR=/etc/rspamd \
 +	cd $(builddir)$* && cmake ../../../  -DCONFDIR=/usr/share/rspamd/config \
 +		-DLOCAL_CONFDIR=/etc/rspamd \
-+		-DENABLE_FASTTEXT=ON \
+ 		-DENABLE_FASTTEXT=ON \
  		-DMANDIR=/usr/share/man \
  		-DRUNDIR=/run/rspamd \
- 		-DDBDIR=/var/lib/rspamd \


### PR DESCRIPTION
Unbreaks docker build if https://github.com/rspamd/rspamd/pull/4961 would be landed

Compounds problems for rspamd-3.8; probably that deserves its own branch