### PR TITLE
Fix "TCP backlog setting" error for redis container

### DIFF
--- a/examples/compose/compose.yaml
+++ b/examples/compose/compose.yaml
@@ -28,6 +28,8 @@ services:
     container_name: rspamd-compose-redis
     command: "redis-server --save 60 1 --loglevel warning"
     image: "redis:latest"
+    sysctls:
+      - net.core.somaxconn=4096
     networks:
       - rspamd
     volumes:


### PR DESCRIPTION
The redis container creates an error.
```
WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
```

References
- https://github.com/redis/docker-library-redis/issues/35
- [Mailcow compose file](https://github.com/mailcow/mailcow-dockerized/blob/a632980871d6b94087cfd513c92cd9cad6f7e819/docker-compose.yml#L59)