### PR TITLE
Upgrade libxml2 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV ASAN_TAG=$ASAN_TAG
 
 RUN	--mount=type=cache,from=pkg,source=/deb,target=/deb \
 	apt-get update \
+    && apt-get upgrade -y libxml2
 	&& apt-get install -y `bash -c "dpkg -I /deb/rspamd${ASAN_TAG}_*_*.deb | grep '^ Depends:' | perl -p -e 's#Depends: |,|\||\([^)]*\)##g'"` \
 	&& apt-get -q clean \
 	&& rm -rf /var/cache/ldconfig/aux-cache /var/lib/apt/lists/* /var/log/apt/*.log /var/log/dpkg.log \


### PR DESCRIPTION
# Description 

The security github action is faling since a few days due to [CVE-2025-49794](https://nvd.nist.gov/vuln/detail/CVE-2025-49794)
This change upgrades libxml2 version and should fix the issue

Note: I haven't tested rspamd e2e
