### PR TITLE
Allow Dockerhub push to be skipped

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -55,13 +55,21 @@ jobs:
           done
           docker buildx imagetools create ${TAGLIST} ${IMAGES}
 
+      - name: Check for Dockerhub secrets
+        run: |
+          if [ -n "${{ secrets.DOCKER_USERNAME }}" ]; then
+            echo "HAVE_DOCKERHUB=1" >> $GITHUB_ENV
+          fi
+
       - name: Log in to Dockerhub
+        if: ${{ env.HAVE_DOCKERHUB }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push release image to Dockerhub
+        if: ${{ env.HAVE_DOCKERHUB }}
         run: |
           IFS=, read -a tags <<< "${{ inputs.dockerhub_tags_release }}"
           IMAGES="${{ inputs.images }}"
@@ -73,6 +81,7 @@ jobs:
           docker buildx imagetools create ${TAGLIST} ${IMAGES}
 
       - name: Push ASAN image to Dockerhub
+        if: ${{ env.HAVE_DOCKERHUB }}
         run: |
           IFS=, read -a tags <<< "${{ inputs.dockerhub_tags_asan }}"
           IMAGES="${{ inputs.images_asan }}"


### PR DESCRIPTION
Allow Dockerhub push to be skipped if secrets aren't defined; that will be better for contributors who unlikely care to bother with it.