### PR TITLE
Add package image tag as label

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -89,6 +89,8 @@ jobs:
           build-args: |
             PKG_IMG=ghcr.io/${{ github.repository }}
             PKG_TAG=pkg${{ env.PKG_TAG_SUFFIX }}
+          labels: |
+            com.rspamd.pkg-tag=pkg${{ env.PKG_TAG_SUFFIX }}
           file: Dockerfile
           push: true
           tags: ""


### PR DESCRIPTION
I want that for #47 - i.e. to be able to find the package the productive image has installed.

Adding some tag like `pkg-latest-amd64` could do as an alternative but is less favorable.