### PR TITLE
Add `pkg-latest`/`pkg-nightly` tag

### DIFF
--- a/.github/workflows/build_test_promote.yml
+++ b/.github/workflows/build_test_promote.yml
@@ -54,6 +54,8 @@ jobs:
       dockerhub_tags_release: ${{ steps.save_output.outputs.dockerhub_tags_release }}
       ghcr_tags_asan: ${{ steps.save_output.outputs.ghcr_tags_asan }}
       ghcr_tags_release: ${{ steps.save_output.outputs.ghcr_tags_release }}
+      ghcr_tags_package: ${{ steps.save_output.outputs.ghcr_tags_package }}
+      dockerhub_tags_package: ${{ steps.save_output.outputs.dockerhub_tags_package }}
     runs-on: "ubuntu-22.04"
     steps:
       - name: Set nightly-specific variables
@@ -61,8 +63,10 @@ jobs:
         run: |
           echo "IMG_TAGS_GHCR_ASAN=ghcr.io/${{ github.repository }}:asan-nightly" >> "$GITHUB_ENV"
           echo "IMG_TAGS_GHCR_RELEASE=ghcr.io/${{ github.repository }}:nightly" >> "$GITHUB_ENV"
+          echo "IMG_TAGS_GHCR_PKG=ghcr.io/${{ github.repository }}:pkg-nightly" >> "$GITHUB_ENV"
           echo "IMG_TAGS_DOCKERHUB_ASAN=${{ inputs.dockerhub_name }}:asan-nightly" >> "$GITHUB_ENV"
           echo "IMG_TAGS_DOCKERHUB_RELEASE=${{ inputs.dockerhub_name }}:nightly" >> "$GITHUB_ENV"
+          echo "IMG_TAGS_DOCKERHUB_PKG=${{ inputs.dockerhub_name }}:pkg-nightly" >> "$GITHUB_ENV"
 
       - name: Set release-specific variables
         if: ${{ ! inputs.nightly }}
@@ -79,6 +83,8 @@ jobs:
           echo "IMG_TAGS_GHCR_ASAN=ghcr.io/${{ github.repository }}:asan-latest,ghcr.io/${{ github.repository }}:asan-${VERSION_BUILD},ghcr.io/${{ github.repository }}:asan-${VERSION_FULL},ghcr.io/${{ github.repository }}:asan-${VERSION_MAJOR_MINOR},ghcr.io/${{ github.repository }}:asan-${VERSION_MAJOR}" >> "$GITHUB_ENV"
           echo "IMG_TAGS_DOCKERHUB_RELEASE=${{ inputs.dockerhub_name }}:latest,${{ inputs.dockerhub_name }}:${VERSION_BUILD},${{ inputs.dockerhub_name }}:${VERSION_FULL},${{ inputs.dockerhub_name }}:${VERSION_MAJOR_MINOR},${{ inputs.dockerhub_name }}:${VERSION_MAJOR}" >> "$GITHUB_ENV"
           echo "IMG_TAGS_GHCR_RELEASE=ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${VERSION_BUILD},ghcr.io/${{ github.repository }}:${VERSION_FULL},ghcr.io/${{ github.repository }}:${VERSION_MAJOR_MINOR},ghcr.io/${{ github.repository }}:${VERSION_MAJOR}" >> "$GITHUB_ENV"
+          echo "IMG_TAGS_DOCKERHUB_PKG=${{ inputs.dockerhub_name }}:pkg-latest" >> "$GITHUB_ENV"
+          echo "IMG_TAGS_GHCR_PKG=ghcr.io/${{ github.repository }}:pkg-latest" >> "$GITHUB_ENV"
 
       - name: Save output
         id: save_output
@@ -87,6 +93,8 @@ jobs:
           echo "dockerhub_tags_release=${{ env.IMG_TAGS_DOCKERHUB_RELEASE }}" >> $GITHUB_OUTPUT
           echo "ghcr_tags_asan=${{ env.IMG_TAGS_GHCR_ASAN }}" >> $GITHUB_OUTPUT
           echo "ghcr_tags_release=${{ env.IMG_TAGS_GHCR_RELEASE }}" >> $GITHUB_OUTPUT
+          echo "ghcr_tags_package=${{ env.IMG_TAGS_GHCR_PKG }}" >> $GITHUB_OUTPUT
+          echo "dockerhub_tags_package=${{ env.IMG_TAGS_DOCKERHUB_PKG }}" >> $GITHUB_OUTPUT
 
   promote:
     needs: [build_amd64, build_arm64, get_tags, test_amd64, test_arm64]
@@ -94,8 +102,11 @@ jobs:
     with:
       images: ghcr.io/${{ github.repository }}@${{ needs.build_amd64.outputs.digest_release }},ghcr.io/${{ github.repository }}@${{ needs.build_arm64.outputs.digest_release }}
       images_asan: ghcr.io/${{ github.repository }}@${{ needs.build_amd64.outputs.digest_asan }},ghcr.io/${{ github.repository }}@${{ needs.build_arm64.outputs.digest_asan }}
+      images_package: ghcr.io/${{ github.repository }}@${{ needs.build_amd64.outputs.digest_package }},ghcr.io/${{ github.repository }}@${{ needs.build_arm64.outputs.digest_package }}
       dockerhub_tags_asan: "${{ needs.get_tags.outputs.dockerhub_tags_asan }}"
       dockerhub_tags_release: "${{ needs.get_tags.outputs.dockerhub_tags_release }}"
       ghcr_tags_asan: "${{ needs.get_tags.outputs.ghcr_tags_asan }}"
       ghcr_tags_release: "${{ needs.get_tags.outputs.ghcr_tags_release }}"
+      ghcr_tags_package: "${{ needs.get_tags.outputs.ghcr_tags_package }}"
+      dockerhub_tags_package: "${{ needs.get_tags.outputs.dockerhub_tags_package }}"
     secrets: inherit

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -17,6 +17,9 @@ on:
       digest_release:
         description: "Digest of the release image"
         value: ${{ jobs.docker_build.outputs.digest_release }}
+      digest_package:
+        description: "Digest of the package image"
+        value: ${{ jobs.docker_build.outputs.digest_package }}
       tag:
         description: "Tag in rspamd repo to check out for tests"
         value: ${{ jobs.docker_build.outputs.tag }}
@@ -26,6 +29,7 @@ jobs:
     outputs:
       digest_asan: "${{ steps.build_asan.outputs.digest }}"
       digest_release: "${{ steps.build_release.outputs.digest }}"
+      digest_package: "${{ steps.build_pkg.outputs.digest }}"
       tag: ${{ steps.save_output.outputs.tag }}
     runs-on: "${{ (inputs.platform == 'arm64') && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}"
     permissions:
@@ -73,6 +77,7 @@ jobs:
           echo "tag=${{ env.RSPAMD_GIT }}" >> $GITHUB_OUTPUT
 
       - name: Build pkg image
+        id: build_pkg
         uses: docker/build-push-action@v5
         with:
           build-args: |
@@ -104,6 +109,8 @@ jobs:
             ASAN_TAG=-asan
             PKG_IMG=ghcr.io/${{ github.repository }}
             PKG_TAG=pkg${{ env.PKG_TAG_SUFFIX }}
+          labels: |
+            com.rspamd.pkg-tag=pkg${{ env.PKG_TAG_SUFFIX }}
           file: Dockerfile
           push: true
           tags: ""

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -9,16 +9,25 @@ on:
       dockerhub_tags_release:
         required: true
         type: string
+      dockerhub_tags_package:
+        required: true
+        type: string
       ghcr_tags_asan:
         required: true
         type: string
       ghcr_tags_release:
         required: true
         type: string
+      ghcr_tags_package:
+        required: true
+        type: string
       images:
         required: true
         type: string
       images_asan:
+        required: true
+        type: string
+      images_package:
         required: true
         type: string
 
@@ -48,6 +57,17 @@ jobs:
         run: |
           IFS=, read -a tags <<< "${{ inputs.ghcr_tags_asan }}"
           IMAGES="${{ inputs.images_asan }}"
+          IMAGES="${IMAGES//,/ }"
+          for tag in ${tags[@]}
+          do
+            TAGLIST+=" -t ${tag} "
+          done
+          docker buildx imagetools create ${TAGLIST} ${IMAGES}
+
+      - name: Push package image to GHCR
+        run: |
+          IFS=, read -a tags <<< "${{ inputs.ghcr_tags_package }}"
+          IMAGES="${{ inputs.images_package }}"
           IMAGES="${IMAGES//,/ }"
           for tag in ${tags[@]}
           do
@@ -85,6 +105,18 @@ jobs:
         run: |
           IFS=, read -a tags <<< "${{ inputs.dockerhub_tags_asan }}"
           IMAGES="${{ inputs.images_asan }}"
+          IMAGES="${IMAGES//,/ }"
+          for tag in ${tags[@]}
+          do
+            TAGLIST+=" -t ${tag} "
+          done
+          docker buildx imagetools create ${TAGLIST} ${IMAGES}
+
+      - name: Push package image to Dockerhub
+        if: ${{ env.HAVE_DOCKERHUB }}
+        run: |
+          IFS=, read -a tags <<< "${{ inputs.dockerhub_tags_package }}"
+          IMAGES="${{ inputs.images_package }}"
           IMAGES="${IMAGES//,/ }"
           for tag in ${tags[@]}
           do

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DEBIAN_RELEASE=bookworm
 ARG PKG_IMG=ghcr.io/rspamd/rspamd-docker
-ARG PKG_TAG
+ARG PKG_TAG=pkg-latest
 
 FROM ${PKG_IMG}:${PKG_TAG} AS pkg
 


### PR DESCRIPTION
I suppose we want a `pkg-latest` tag after all, primarily so that a casual `docker build .` can work (#33).

Set package tag label on ASAN image too, for consistency...