### PR TITLE
Refresh latest image daily to pick up Debian security updates

### DIFF
--- a/.github/workflows/refresh_build.yml
+++ b/.github/workflows/refresh_build.yml
@@ -1,0 +1,57 @@
+name: refresh_build
+
+# Rebuilds the runtime (release) image for a single platform from the already
+# released package image (pkg-latest) on top of a freshly pulled
+# debian:trixie-slim. rspamd itself is NOT rebuilt from source: only the thin
+# runtime layer is reassembled so the image picks up the current Debian security
+# updates. Pushes the result by digest for the caller to promote.
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        default: amd64
+        type: string
+    outputs:
+      digest:
+        description: "Digest of the rebuilt release image"
+        value: ${{ jobs.refresh_build.outputs.digest }}
+
+jobs:
+  refresh_build:
+    outputs:
+      digest: "${{ steps.build_release.outputs.digest }}"
+    runs-on: "${{ (inputs.platform == 'arm64') && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}"
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # pull + no-cache guarantee the apt-get layer is re-evaluated against the
+      # current debian:trixie-slim and package archive rather than reusing a
+      # cached layer with the previously installed (vulnerable) versions.
+      - name: Build release image
+        id: build_release
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            PKG_IMG=ghcr.io/${{ github.repository }}
+            PKG_TAG=pkg-latest
+          pull: true
+          no-cache: true
+          file: Dockerfile
+          push: true
+          tags: ""
+          outputs: "type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true"

--- a/.github/workflows/refresh_latest.yml
+++ b/.github/workflows/refresh_latest.yml
@@ -1,0 +1,142 @@
+name: refresh_latest
+
+# Keeps the published "latest" release image patched against Debian security
+# updates between rspamd releases. The runtime layer is rebuilt from the
+# released package (pkg-latest), tested, and the floating tags (latest, MAJOR,
+# MAJOR.MINOR) are re-pointed at it. The immutable version-pinned tags
+# (e.g. 4.0.1, 4.0.1-1) are intentionally left untouched.
+#
+# Runs daily a couple of hours before the security scan (security.yml, 00:00)
+# so rspamd/rspamd:latest is freshly patched before it is audited.
+
+on:
+  schedule:
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: rspamd-docker-refresh-latest
+  cancel-in-progress: false
+
+jobs:
+  build_amd64:
+    uses: ./.github/workflows/refresh_build.yml
+    with:
+      platform: amd64
+    permissions:
+      packages: write
+      contents: read
+    secrets: inherit
+
+  build_arm64:
+    uses: ./.github/workflows/refresh_build.yml
+    with:
+      platform: arm64
+    permissions:
+      packages: write
+      contents: read
+    secrets: inherit
+
+  get_tags:
+    runs-on: "ubuntu-22.04"
+    outputs:
+      ghcr_tags: ${{ steps.compute.outputs.ghcr_tags }}
+      dockerhub_tags: ${{ steps.compute.outputs.dockerhub_tags }}
+      rspamd_git: ${{ steps.compute.outputs.rspamd_git }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute floating tags from the newest release
+        id: compute
+        run: |
+          RSPAMD_FULL=$(git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//')
+          VERSION_FULL=${RSPAMD_FULL%%+*}
+          VERSION_MAJOR_MINOR=${VERSION_FULL%.*}
+          VERSION_MAJOR=${VERSION_FULL%%.*}
+          echo "Newest release ${RSPAMD_FULL} -> refreshing tags: latest, ${VERSION_MAJOR_MINOR}, ${VERSION_MAJOR}"
+          GHCR=ghcr.io/${{ github.repository }}
+          DH=rspamd/rspamd
+          {
+            echo "ghcr_tags=${GHCR}:latest,${GHCR}:${VERSION_MAJOR_MINOR},${GHCR}:${VERSION_MAJOR}"
+            echo "dockerhub_tags=${DH}:latest,${DH}:${VERSION_MAJOR_MINOR},${DH}:${VERSION_MAJOR}"
+            echo "rspamd_git=${VERSION_FULL}"
+          } >> "$GITHUB_OUTPUT"
+
+  test_amd64:
+    needs: [build_amd64, get_tags]
+    uses: ./.github/workflows/rspamd_test.yml
+    with:
+      image: ghcr.io/${{ github.repository }}@${{ needs.build_amd64.outputs.digest }}
+      tag: "${{ needs.get_tags.outputs.rspamd_git }}"
+
+  test_arm64:
+    needs: [build_arm64, get_tags]
+    uses: ./.github/workflows/rspamd_test.yml
+    with:
+      image: ghcr.io/${{ github.repository }}@${{ needs.build_arm64.outputs.digest }}
+      tag: "${{ needs.get_tags.outputs.rspamd_git }}"
+      platform: arm64
+
+  promote:
+    needs: [build_amd64, build_arm64, get_tags, test_amd64, test_arm64]
+    runs-on: "ubuntu-22.04"
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      # Can be removed when there'd be 0.30.1+ on GH runners
+      - name: Upgrade buildx
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y moby-buildx
+          docker buildx version
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-point floating release tags on GHCR
+        run: |
+          IFS=, read -r -a tags <<< "${{ needs.get_tags.outputs.ghcr_tags }}"
+          for tag in "${tags[@]}"
+          do
+            TAGLIST+=" -t ${tag} "
+          done
+          # TAGLIST holds multiple "-t <tag>" args that must word-split.
+          # shellcheck disable=SC2086
+          docker buildx imagetools create ${TAGLIST} \
+            ghcr.io/${{ github.repository }}@${{ needs.build_amd64.outputs.digest }} \
+            ghcr.io/${{ github.repository }}@${{ needs.build_arm64.outputs.digest }}
+
+      - name: Check for Dockerhub secrets
+        run: |
+          if [ -n "${{ secrets.DOCKER_USERNAME }}" ]; then
+            echo "HAVE_DOCKERHUB=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Log in to Dockerhub
+        if: ${{ env.HAVE_DOCKERHUB }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Re-point floating release tags on Dockerhub
+        if: ${{ env.HAVE_DOCKERHUB }}
+        run: |
+          IFS=, read -r -a tags <<< "${{ needs.get_tags.outputs.dockerhub_tags }}"
+          for tag in "${tags[@]}"
+          do
+            TAGLIST+=" -t ${tag} "
+          done
+          # TAGLIST holds multiple "-t <tag>" args that must word-split.
+          # shellcheck disable=SC2086
+          docker buildx imagetools create ${TAGLIST} \
+            ghcr.io/${{ github.repository }}@${{ needs.build_amd64.outputs.digest }} \
+            ghcr.io/${{ github.repository }}@${{ needs.build_arm64.outputs.digest }}


### PR DESCRIPTION
## Problem

The `security` workflow scans `rspamd/rspamd:latest` daily with `grype --only-fixed --fail-on low`. But `latest` is only rebuilt by the `release` workflow (on a version-tag push), so it's a **frozen release artifact**. Between rspamd releases, Debian ships trixie security point-updates and grype flags the stale packages.

It has failed every day since **2026-05-18** (passed cleanly through 05-17), when a batch of trixie updates landed: `libc6`/`libc-bin` (→`deb13u3`), `libarchive13t64` (→`deb13u1`, incl. one Critical), `libsystemd0`/`libudev1` (→`257.13`), `libcap2`, `libglib2.0`, `sed`.

Proof a rebuild fixes it — scanning both tags today:

| Tag | Rebuilt | Fixable CVEs |
|-----|---------|--------------|
| `nightly` | every night, fresh `debian:trixie-slim` | **0** |
| `latest` | only on a release | **29** |

## Fix

New `refresh_latest` workflow (+ reusable `refresh_build`) that, daily at 22:00 UTC (2h before the 00:00 security scan):

1. Rebuilds **only the thin runtime layer** from the already-released package image (`pkg-latest`) on a freshly pulled `debian:trixie-slim` — picks up current Debian security updates. rspamd is **not** rebuilt from source.
2. Runs the existing functional test suite (`rspamd_test.yml`) on the rebuilt image (both amd64 + arm64).
3. Re-points the **floating** tags `latest`, `MAJOR`, `MAJOR.MINOR` (and Dockerhub equivalents) at the patched multi-arch image.

The immutable version-pinned tags (e.g. `4.0.1`, `4.0.1-1`) are intentionally left untouched. `latest` self-heals between releases and the security scan goes green on its own.

## Notes / follow-ups
- ASAN tags (`asan-latest`, …) are not refreshed — they aren't security-scanned. Easy to add if wanted.
- The standalone `security.yml` is unchanged; it still has a visibility gap (SARIF output is written to a temp file and discarded, so failures don't show *which* CVE in the log). Worth a small follow-up to print a table / upload SARIF to the Security tab.
- Cadence/tests can be dialed down (weekly, or a lighter smoke test) to cut CI minutes if the daily full functional run is too heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)