### PR TITLE
Docker best practices: dockerignore/LICENSE, compute-tags action, build-scan gate + SBOM

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep the build context minimal — none of these are needed to build the image.
+# The runtime Dockerfile only needs lid.176.ftz (+ the Dockerfiles themselves);
+# Dockerfile.pkg fetches rspamd from git and needs nothing from the context.
+.git
+.github
+.claude
+examples/
+*.md
+LICENSE

--- a/.github/actions/compute-tags/action.yml
+++ b/.github/actions/compute-tags/action.yml
@@ -149,4 +149,5 @@ runs:
           echo "org.opencontainers.image.licenses=Apache-2.0"
           echo "org.opencontainers.image.version=${version}"
           echo "org.opencontainers.image.revision=${REV}"
+          echo "__OCI__"
         } >> "$GITHUB_OUTPUT"

--- a/.github/actions/compute-tags/action.yml
+++ b/.github/actions/compute-tags/action.yml
@@ -1,0 +1,152 @@
+name: compute-tags
+description: >-
+  Compute build arguments, image tag lists and OCI labels for rspamd-docker
+  builds. Centralises the version parsing that was previously duplicated across
+  docker_build.yml, build_test_promote.yml and refresh_latest.yml.
+
+inputs:
+  nightly:
+    description: '"true" for nightly builds, "false" for tagged releases'
+    required: true
+  ref_name:
+    description: 'Release tag to parse (e.g. v4.0.1+1); defaults to the triggering ref'
+    required: false
+    default: ${{ github.ref_name }}
+  platform:
+    description: 'Target platform (amd64/arm64); appended to the per-platform pkg tag suffix'
+    required: false
+    default: ''
+  repository:
+    description: 'GHCR repository (owner/name)'
+    required: false
+    default: ${{ github.repository }}
+  dockerhub_name:
+    description: 'Docker Hub image name'
+    required: false
+    default: rspamd/rspamd
+  floating_only:
+    description: 'Emit only the floating release tags (latest, MAJOR, MAJOR.MINOR)'
+    required: false
+    default: 'false'
+
+outputs:
+  pkg_tag_suffix:
+    description: 'Suffix for the pkg image tag (e.g. -nightly-amd64, -4.0.1-1-amd64)'
+    value: ${{ steps.c.outputs.pkg_tag_suffix }}
+  rspamd_git:
+    description: 'rspamd git ref to build/test (master or the release version)'
+    value: ${{ steps.c.outputs.rspamd_git }}
+  rspamd_version:
+    description: 'rspamd version build-arg (auto for nightly, else the release version)'
+    value: ${{ steps.c.outputs.rspamd_version }}
+  tag:
+    description: 'rspamd ref to check out for tests (alias of rspamd_git)'
+    value: ${{ steps.c.outputs.rspamd_git }}
+  version:
+    description: 'Human version string for labels (nightly or the release version)'
+    value: ${{ steps.c.outputs.version }}
+  ghcr_tags_release:
+    value: ${{ steps.c.outputs.ghcr_tags_release }}
+  ghcr_tags_asan:
+    value: ${{ steps.c.outputs.ghcr_tags_asan }}
+  ghcr_tags_package:
+    value: ${{ steps.c.outputs.ghcr_tags_package }}
+  dockerhub_tags_release:
+    value: ${{ steps.c.outputs.dockerhub_tags_release }}
+  dockerhub_tags_asan:
+    value: ${{ steps.c.outputs.dockerhub_tags_asan }}
+  dockerhub_tags_package:
+    value: ${{ steps.c.outputs.dockerhub_tags_package }}
+  labels:
+    description: 'Newline-separated OCI image labels'
+    value: ${{ steps.c.outputs.labels }}
+
+runs:
+  using: composite
+  steps:
+    - id: c
+      shell: bash
+      env:
+        NIGHTLY: ${{ inputs.nightly }}
+        REF_NAME: ${{ inputs.ref_name }}
+        PLATFORM: ${{ inputs.platform }}
+        REPO: ${{ inputs.repository }}
+        DH: ${{ inputs.dockerhub_name }}
+        FLOATING_ONLY: ${{ inputs.floating_only }}
+        REV: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        # Prefix every comma-separated tag in $2 with $1 and re-join with commas.
+        prefix() {
+          local p="$1" out="" e IFS=,
+          for e in $2; do out="${out:+$out,}${p}${e}"; done
+          printf '%s' "$out"
+        }
+
+        GHCR="ghcr.io/${REPO}"
+        plat_suffix=""
+        [ -n "${PLATFORM}" ] && plat_suffix="-${PLATFORM}"
+
+        if [ "${NIGHTLY}" = "true" ]; then
+          pkg_tag_suffix="-nightly${plat_suffix}"
+          rspamd_git="master"
+          rspamd_version="auto"
+          version="nightly"
+          ghcr_tags_release="${GHCR}:nightly"
+          ghcr_tags_asan="${GHCR}:asan-nightly"
+          ghcr_tags_package="${GHCR}:pkg-nightly"
+          dockerhub_tags_release="${DH}:nightly"
+          dockerhub_tags_asan="${DH}:asan-nightly"
+          dockerhub_tags_package="${DH}:pkg-nightly"
+        else
+          v="${REF_NAME#v}"                            # 4.0.1+1
+          version_build="${v/+/-}"                     # 4.0.1-1 (first + only)
+          version_full="${v%%+*}"                      # 4.0.1
+          version_major_minor="${version_full%.*}"     # 4.0
+          version_major="${version_full%%.*}"          # 4
+          rspamd_git="${version_full}"
+          rspamd_version="${version_full}"
+          version="${version_full}"
+          rs="${REF_NAME/+/-}"; rs="${rs#v}"           # 4.0.1-1
+          pkg_tag_suffix="-${rs}${plat_suffix}"
+          if [ "${FLOATING_ONLY}" = "true" ]; then
+            rel="latest,${version_major_minor},${version_major}"
+            asan="asan-latest,asan-${version_major_minor},asan-${version_major}"
+          else
+            rel="latest,${version_build},${version_full},${version_major_minor},${version_major}"
+            asan="asan-latest,asan-${version_build},asan-${version_full},asan-${version_major_minor},asan-${version_major}"
+          fi
+          ghcr_tags_release="$(prefix "${GHCR}:" "${rel}")"
+          ghcr_tags_asan="$(prefix "${GHCR}:" "${asan}")"
+          ghcr_tags_package="${GHCR}:pkg-latest"
+          dockerhub_tags_release="$(prefix "${DH}:" "${rel}")"
+          dockerhub_tags_asan="$(prefix "${DH}:" "${asan}")"
+          dockerhub_tags_package="${DH}:pkg-latest"
+        fi
+
+        {
+          echo "pkg_tag_suffix=${pkg_tag_suffix}"
+          echo "rspamd_git=${rspamd_git}"
+          echo "rspamd_version=${rspamd_version}"
+          echo "version=${version}"
+          echo "ghcr_tags_release=${ghcr_tags_release}"
+          echo "ghcr_tags_asan=${ghcr_tags_asan}"
+          echo "ghcr_tags_package=${ghcr_tags_package}"
+          echo "dockerhub_tags_release=${dockerhub_tags_release}"
+          echo "dockerhub_tags_asan=${dockerhub_tags_asan}"
+          echo "dockerhub_tags_package=${dockerhub_tags_package}"
+        } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "labels<<__OCI__"
+          echo "org.opencontainers.image.source=https://github.com/${REPO}"
+          echo "org.opencontainers.image.url=https://rspamd.com"
+          echo "org.opencontainers.image.documentation=https://rspamd.com/doc/"
+          echo "org.opencontainers.image.title=Rspamd"
+          echo "org.opencontainers.image.description=Rspamd spam filtering system"
+          echo "org.opencontainers.image.vendor=Rspamd"
+          echo "org.opencontainers.image.licenses=Apache-2.0"
+          echo "org.opencontainers.image.version=${version}"
+          echo "org.opencontainers.image.revision=${REV}"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_test_promote.yml
+++ b/.github/workflows/build_test_promote.yml
@@ -50,51 +50,23 @@ jobs:
 
   get_tags:
     outputs:
-      dockerhub_tags_asan: ${{ steps.save_output.outputs.dockerhub_tags_asan }}
-      dockerhub_tags_release: ${{ steps.save_output.outputs.dockerhub_tags_release }}
-      ghcr_tags_asan: ${{ steps.save_output.outputs.ghcr_tags_asan }}
-      ghcr_tags_release: ${{ steps.save_output.outputs.ghcr_tags_release }}
-      ghcr_tags_package: ${{ steps.save_output.outputs.ghcr_tags_package }}
-      dockerhub_tags_package: ${{ steps.save_output.outputs.dockerhub_tags_package }}
+      dockerhub_tags_asan: ${{ steps.compute.outputs.dockerhub_tags_asan }}
+      dockerhub_tags_release: ${{ steps.compute.outputs.dockerhub_tags_release }}
+      ghcr_tags_asan: ${{ steps.compute.outputs.ghcr_tags_asan }}
+      ghcr_tags_release: ${{ steps.compute.outputs.ghcr_tags_release }}
+      ghcr_tags_package: ${{ steps.compute.outputs.ghcr_tags_package }}
+      dockerhub_tags_package: ${{ steps.compute.outputs.dockerhub_tags_package }}
     runs-on: "ubuntu-22.04"
     steps:
-      - name: Set nightly-specific variables
-        if: ${{ inputs.nightly }}
-        run: |
-          echo "IMG_TAGS_GHCR_ASAN=ghcr.io/${{ github.repository }}:asan-nightly" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_GHCR_RELEASE=ghcr.io/${{ github.repository }}:nightly" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_GHCR_PKG=ghcr.io/${{ github.repository }}:pkg-nightly" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_DOCKERHUB_ASAN=${{ inputs.dockerhub_name }}:asan-nightly" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_DOCKERHUB_RELEASE=${{ inputs.dockerhub_name }}:nightly" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_DOCKERHUB_PKG=${{ inputs.dockerhub_name }}:pkg-nightly" >> "$GITHUB_ENV"
+      - name: Check out source code
+        uses: actions/checkout@v4
 
-      - name: Set release-specific variables
-        if: ${{ ! inputs.nightly }}
-        run: |
-          export VERSION_BUILD=`echo ${{ github.ref_name }} | sed s/^v// | sed 's/\+/-/'`
-          echo "VERSION_BUILD=${VERSION_BUILD}" >> "$GITHUB_ENV"
-          export VERSION_FULL=`echo ${{ github.ref_name }} | sed s/^v// | sed 's/\+.*//'`
-          echo "VERSION_FULL=${VERSION_FULL}" >> "$GITHUB_ENV"
-          export VERSION_MAJOR_MINOR=${VERSION_FULL%.*}
-          echo "VERSION_MAJOR_MINOR=${VERSION_MAJOR_MINOR}" >> "$GITHUB_ENV"
-          export VERSION_MAJOR=`echo ${{ github.ref_name }} | sed s/^v// | sed 's/[^0-9].*//'`
-          echo "VERSION_MAJOR=${VERSION_MAJOR}" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_DOCKERHUB_ASAN=${{ inputs.dockerhub_name }}:asan-latest,${{ inputs.dockerhub_name }}:asan-${VERSION_BUILD},${{ inputs.dockerhub_name }}:asan-${VERSION_FULL},${{ inputs.dockerhub_name }}:asan-${VERSION_MAJOR_MINOR},${{ inputs.dockerhub_name }}:asan-${VERSION_MAJOR}" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_GHCR_ASAN=ghcr.io/${{ github.repository }}:asan-latest,ghcr.io/${{ github.repository }}:asan-${VERSION_BUILD},ghcr.io/${{ github.repository }}:asan-${VERSION_FULL},ghcr.io/${{ github.repository }}:asan-${VERSION_MAJOR_MINOR},ghcr.io/${{ github.repository }}:asan-${VERSION_MAJOR}" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_DOCKERHUB_RELEASE=${{ inputs.dockerhub_name }}:latest,${{ inputs.dockerhub_name }}:${VERSION_BUILD},${{ inputs.dockerhub_name }}:${VERSION_FULL},${{ inputs.dockerhub_name }}:${VERSION_MAJOR_MINOR},${{ inputs.dockerhub_name }}:${VERSION_MAJOR}" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_GHCR_RELEASE=ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${VERSION_BUILD},ghcr.io/${{ github.repository }}:${VERSION_FULL},ghcr.io/${{ github.repository }}:${VERSION_MAJOR_MINOR},ghcr.io/${{ github.repository }}:${VERSION_MAJOR}" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_DOCKERHUB_PKG=${{ inputs.dockerhub_name }}:pkg-latest" >> "$GITHUB_ENV"
-          echo "IMG_TAGS_GHCR_PKG=ghcr.io/${{ github.repository }}:pkg-latest" >> "$GITHUB_ENV"
-
-      - name: Save output
-        id: save_output
-        run: |
-          echo "dockerhub_tags_asan=${{ env.IMG_TAGS_DOCKERHUB_ASAN }}" >> $GITHUB_OUTPUT
-          echo "dockerhub_tags_release=${{ env.IMG_TAGS_DOCKERHUB_RELEASE }}" >> $GITHUB_OUTPUT
-          echo "ghcr_tags_asan=${{ env.IMG_TAGS_GHCR_ASAN }}" >> $GITHUB_OUTPUT
-          echo "ghcr_tags_release=${{ env.IMG_TAGS_GHCR_RELEASE }}" >> $GITHUB_OUTPUT
-          echo "ghcr_tags_package=${{ env.IMG_TAGS_GHCR_PKG }}" >> $GITHUB_OUTPUT
-          echo "dockerhub_tags_package=${{ env.IMG_TAGS_DOCKERHUB_PKG }}" >> $GITHUB_OUTPUT
+      - name: Compute tags
+        id: compute
+        uses: ./.github/actions/compute-tags
+        with:
+          nightly: ${{ inputs.nightly }}
+          dockerhub_name: ${{ inputs.dockerhub_name }}
 
   promote:
     needs: [build_amd64, build_arm64, get_tags, test_amd64, test_arm64]

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -30,7 +30,7 @@ jobs:
       digest_asan: "${{ steps.build_asan.outputs.digest }}"
       digest_release: "${{ steps.build_release.outputs.digest }}"
       digest_package: "${{ steps.build_pkg.outputs.digest }}"
-      tag: ${{ steps.save_output.outputs.tag }}
+      tag: ${{ steps.compute.outputs.tag }}
     runs-on: "${{ (inputs.platform == 'arm64') && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}"
     permissions:
       packages: write
@@ -49,43 +49,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set nightly-specific variables
-        if: ${{ inputs.nightly }}
-        run: |
-          echo "PKG_TAG_SUFFIX=-nightly-${{ inputs.platform }}" >> "$GITHUB_ENV"
-          echo "RSPAMD_GIT=master" >> "$GITHUB_ENV"
-          echo "RSPAMD_VERSION=auto" >> "$GITHUB_ENV"
-
-      - name: Set release-specific variables
-        if: ${{ ! inputs.nightly }}
-        run: |
-          export VERSION_BUILD=`echo ${{ github.ref_name }} | sed s/^v// | sed 's/\+/-/'`
-          echo "VERSION_BUILD=${VERSION_BUILD}" >> "$GITHUB_ENV"
-          export VERSION_FULL=`echo ${{ github.ref_name }} | sed s/^v// | sed 's/\+.*//'`
-          echo "VERSION_FULL=${VERSION_FULL}" >> "$GITHUB_ENV"
-          export VERSION_MAJOR_MINOR=${VERSION_FULL%.*}
-          echo "VERSION_MAJOR_MINOR=${VERSION_MAJOR_MINOR}" >> "$GITHUB_ENV"
-          export VERSION_MAJOR=`echo ${{ github.ref_name }} | sed s/^v// | sed 's/[^0-9].*//'`
-          echo "VERSION_MAJOR=${VERSION_MAJOR}" >> "$GITHUB_ENV"
-          echo "PKG_TAG_SUFFIX=-`echo ${{ github.ref_name }} | sed s/+/-/ | sed s/^v//`-${{ inputs.platform }}" >> "$GITHUB_ENV"
-          echo "RSPAMD_GIT=`echo ${{ github.ref_name }} | sed s/^v// | sed s/+.*//`" >> "$GITHUB_ENV"
-          echo "RSPAMD_VERSION=`echo ${{ github.ref_name }} | sed s/^v// | sed s/+.*//`" >> "$GITHUB_ENV"
-
-      - name: Save output
-        id: save_output
-        run: |
-          echo "tag=${{ env.RSPAMD_GIT }}" >> $GITHUB_OUTPUT
+      - name: Compute build args, tags and labels
+        id: compute
+        uses: ./.github/actions/compute-tags
+        with:
+          nightly: ${{ inputs.nightly }}
+          platform: ${{ inputs.platform }}
 
       - name: Build pkg image
         id: build_pkg
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            RSPAMD_GIT=${{ env.RSPAMD_GIT }}
-            RSPAMD_VERSION=${{ env.RSPAMD_VERSION }}
+            RSPAMD_GIT=${{ steps.compute.outputs.rspamd_git }}
+            RSPAMD_VERSION=${{ steps.compute.outputs.rspamd_version }}
           file: Dockerfile.pkg
           push: true
-          tags: ghcr.io/${{ github.repository }}:pkg${{ env.PKG_TAG_SUFFIX }}
+          tags: ghcr.io/${{ github.repository }}:pkg${{ steps.compute.outputs.pkg_tag_suffix }}
 
       - name: Build release image
         id: build_release
@@ -93,9 +73,10 @@ jobs:
         with:
           build-args: |
             PKG_IMG=ghcr.io/${{ github.repository }}
-            PKG_TAG=pkg${{ env.PKG_TAG_SUFFIX }}
+            PKG_TAG=pkg${{ steps.compute.outputs.pkg_tag_suffix }}
           labels: |
-            com.rspamd.pkg-tag=pkg${{ env.PKG_TAG_SUFFIX }}
+            ${{ steps.compute.outputs.labels }}
+            com.rspamd.pkg-tag=pkg${{ steps.compute.outputs.pkg_tag_suffix }}
           file: Dockerfile
           push: true
           tags: ""
@@ -108,9 +89,10 @@ jobs:
           build-args: |
             ASAN_TAG=-asan
             PKG_IMG=ghcr.io/${{ github.repository }}
-            PKG_TAG=pkg${{ env.PKG_TAG_SUFFIX }}
+            PKG_TAG=pkg${{ steps.compute.outputs.pkg_tag_suffix }}
           labels: |
-            com.rspamd.pkg-tag=pkg${{ env.PKG_TAG_SUFFIX }}
+            ${{ steps.compute.outputs.labels }}
+            com.rspamd.pkg-tag=pkg${{ steps.compute.outputs.pkg_tag_suffix }}
           file: Dockerfile
           push: true
           tags: ""

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -82,6 +82,25 @@ jobs:
           tags: ""
           outputs: "type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true"
 
+      - name: Generate SBOM for the release image
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.build_release.outputs.digest }}
+          format: spdx-json
+          artifact-name: sbom-${{ inputs.platform }}.spdx.json
+
+      # Gate: a *fixable* high/critical vulnerability fails the build before the
+      # image can be tested or promoted. The daily security.yml keeps the broader
+      # low-severity report; this only blocks serious, actionable issues.
+      - name: Scan release image (gate)
+        uses: anchore/scan-action@v7
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.build_release.outputs.digest }}
+          only-fixed: true
+          severity-cutoff: high
+          fail-build: true
+          output-format: table
+
       - name: Build ASAN image
         id: build_asan
         uses: docker/build-push-action@v5

--- a/.github/workflows/refresh_latest.yml
+++ b/.github/workflows/refresh_latest.yml
@@ -40,8 +40,8 @@ jobs:
   get_tags:
     runs-on: "ubuntu-22.04"
     outputs:
-      ghcr_tags: ${{ steps.compute.outputs.ghcr_tags }}
-      dockerhub_tags: ${{ steps.compute.outputs.dockerhub_tags }}
+      ghcr_tags: ${{ steps.compute.outputs.ghcr_tags_release }}
+      dockerhub_tags: ${{ steps.compute.outputs.dockerhub_tags_release }}
       rspamd_git: ${{ steps.compute.outputs.rspamd_git }}
     steps:
       - name: Check out source code
@@ -49,21 +49,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Compute floating tags from the newest release
+      - name: Find the newest release tag
+        id: newest
+        run: echo "ref=$(git tag -l 'v*' --sort=-v:refname | head -1)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute floating tags
         id: compute
-        run: |
-          RSPAMD_FULL=$(git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//')
-          VERSION_FULL=${RSPAMD_FULL%%+*}
-          VERSION_MAJOR_MINOR=${VERSION_FULL%.*}
-          VERSION_MAJOR=${VERSION_FULL%%.*}
-          echo "Newest release ${RSPAMD_FULL} -> refreshing tags: latest, ${VERSION_MAJOR_MINOR}, ${VERSION_MAJOR}"
-          GHCR=ghcr.io/${{ github.repository }}
-          DH=rspamd/rspamd
-          {
-            echo "ghcr_tags=${GHCR}:latest,${GHCR}:${VERSION_MAJOR_MINOR},${GHCR}:${VERSION_MAJOR}"
-            echo "dockerhub_tags=${DH}:latest,${DH}:${VERSION_MAJOR_MINOR},${DH}:${VERSION_MAJOR}"
-            echo "rspamd_git=${VERSION_FULL}"
-          } >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/compute-tags
+        with:
+          nightly: "false"
+          ref_name: ${{ steps.newest.outputs.ref }}
+          floating_only: "true"
 
   test_amd64:
     needs: [build_amd64, get_tags]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Vsevolod Stakhov and the Rspamd authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Implements the agreed best-practices scope (Quick wins + DRY workflows + Supply chain). Each commit is self-contained.

## Quick wins
- **`.dockerignore`** — the build context was shipping `.git`, `.github`, `examples/` and docs to the daemon on every build; now trimmed to what the Dockerfiles actually use.
- **`LICENSE`** — adds the missing top-level Apache-2.0 (canonical text, matching rspamd).
- **OCI labels** — images now carry `org.opencontainers.image.{source,revision,version,licenses,title,description,url,documentation,vendor}` (emitted by the new action), so GHCR links back to the repo and pulls have provenance metadata.

## DRY: `compute-tags` composite action
The `vX.Y.Z+B` → tag parsing was duplicated in **three** workflows as slightly different `sed` pipelines. Extracted into `.github/actions/compute-tags`, which emits the build args, GHCR/Docker Hub tag lists, and OCI labels. A `floating_only` mode serves `refresh_latest`'s `latest`/`MAJOR`/`MAJOR.MINOR` subset.

Net **−92 lines** of duplicated logic. Verified before swapping callers:
- a parity harness diffs the new bash against the original `sed` logic — **byte-identical** tag lists / build args for nightly, release (`v4.0.1+1`, `v3.14.3+2`, 2-digit builds) and floating cases;
- the run block was executed against a simulated `$GITHUB_OUTPUT` to confirm well-formed output (including the multiline `labels` heredoc) for nightly/release/floating.

## Supply chain
- **Scan gate** — `docker_build.yml` now scans the freshly built release image with grype and **fails on any fixable high/critical** before it can be tested or promoted, so vulnerable images never reach the published tags. (`security.yml` keeps the broader daily low-severity report.)
- **SBOM** — an SPDX SBOM is generated per platform and uploaded as a build artifact.
- Intentionally **not** gating `refresh_latest`: blocking it on a residual fixable CVE would keep `latest` pinned to the *older, more-vulnerable* image — the refresh is strictly an improvement.

## Deliberately deferred (need a CI validation pass)
- **OCI provenance attestation + cosign signing** — the builds use `push-by-digest=true` + `imagetools create` promotion; enabling build-push-action provenance on push-by-digest interacts with that merge step in ways I couldn't validate locally. Not worth risking the release pipeline blind — clean follow-up once confirmed in CI.
- **`Dockerfile` `apt-get install ./*.deb` simplification** — sits on the `adduser`/UID-11333 logic stabilised in the last few commits; left untouched on purpose.
- **Splitting `rspamd-dbg` into a `:debug` image** — not selected.

## Validation notes
`actionlint` is clean on all changed files (the only warnings are long-standing ones in the untouched `promote.yml`/`rspamd_test.yml`). The build-flow changes (scan gate, SBOM, label plumbing) can only be fully exercised by a nightly run — happy to dispatch `nightly` from this branch's logic after merge to confirm end-to-end before the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)